### PR TITLE
Replace deprecated implicit conversion from float to int by deliberat…

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -106,7 +106,7 @@ class SteamTotp {
 
         $code = '';
         for ($i = 0; $i < self::CODE_LENGTH; $i++) {
-            $code .= substr(self::CHARSET, $fullcode % strlen(self::CHARSET), 1);
+            $code .= substr(self::CHARSET, (int) $fullcode % strlen(self::CHARSET), 1);
             $fullcode /= strlen(self::CHARSET);
         }
 


### PR DESCRIPTION
…ely casting to int.

This fixes the 

> <b>Deprecated</b>:  Implicit conversion from float ... to int loses precision in <b>/var/www/html/index.php</b> on line <b>109</b><br />

error.